### PR TITLE
feat: create ingress based external access

### DIFF
--- a/charts/confluent/Chart.yaml
+++ b/charts/confluent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lsdmesp-confluent
-version: "0.4.2"
-appVersion: "0.4.2"
+version: "0.5.0"
+appVersion: "0.5.0"
 description: 'LSDMESP CFK: LSD Event Streaming Platform with Confluent Operator'
 keywords:
   - lsdmesp

--- a/charts/confluent/templates/011.kafka-ingress.yaml
+++ b/charts/confluent/templates/011.kafka-ingress.yaml
@@ -1,0 +1,53 @@
+{{- $kafka := .Values.lsdmesp.confluent.kafka -}}
+{{- if $kafka.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-kafka
+spec:
+  ingressClassName: {{ $kafka.ingress.ingressClassName }}
+  rules:
+    - host: kafka.{{ $kafka.ingress.baseDomain }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: kafka
+                port:
+                  number: 9092
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - kafka.{{ $kafka.ingress.baseDomain }}
+      secretName: {{ $kafka.ingress.tls.secretName }}
+{{- range $i := $kafka.replicas -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-kafka-broker-{{ $i }}
+{{- with $kafka.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ $kafka.ingress.ingressClassName }}
+  rules:
+    - host: kafka-broker-{{ $i }}.{{ $kafka.ingress.baseDomain }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: kafka
+                port:
+                  number: 9092
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - kafka-broker-{{ $i }}.{{ $kafka.ingress.baseDomain }}
+      secretName: {{ $kafka.ingress.tls.secretName }}-{{ $i }}
+{{- end -}}
+{{- end -}}

--- a/charts/confluent/templates/011.kafka.yaml
+++ b/charts/confluent/templates/011.kafka.yaml
@@ -70,7 +70,16 @@ spec:
       tls:
         enabled: true
     external:
-      # externalAccess: {} // TODO: Needs to be added 
+      externalAccess:
+        {{- if $kafka.ingress.enabled -}}
+        type: staticForHostBasedRouting
+        staticForHostBasedRouting:
+          domain: {{ $kafka.ingress.baseDomain }}
+          brokerPrefix: kafka-broker-
+          port: 443
+        {{- else -}}
+        {{- toYaml  $kafka.externalAccess | nindent 8 }}
+        {{- end -}}
       authentication:
         type: ldap
       tls:

--- a/charts/confluent/templates/020.schemaregistry-ingress.yaml
+++ b/charts/confluent/templates/020.schemaregistry-ingress.yaml
@@ -1,0 +1,25 @@
+{{- $schemaregistry := .Values.lsdmesp.confluent.schemaregistry -}}
+{{- if $schemaregistry.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-schemaregistry
+spec:
+  ingressClassName: {{ $schemaregistry.ingress.ingressClassName }}
+  rules:
+    - host: schemaregistry.{{ $schemaregistry.ingress.baseDomain }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: schemaregistry
+                port:
+                  number: 9092
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - schemaregistry.{{ $schemaregistry.ingress.baseDomain }}
+      secretName: {{ $schemaregistry.ingress.tls.secretName }}
+{{- end -}}

--- a/charts/confluent/templates/030.connect-ingress.yaml
+++ b/charts/confluent/templates/030.connect-ingress.yaml
@@ -1,0 +1,25 @@
+{{- $connect := .Values.lsdmesp.confluent.connect -}}
+{{- if $connect.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-connect
+spec:
+  ingressClassName: {{ $connect.ingress.ingressClassName }}
+  rules:
+    - host: connect.{{ $connect.ingress.baseDomain }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: connect
+                port:
+                  number: 9092
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - connect.{{ $connect.ingress.baseDomain }}
+      secretName: {{ $connect.ingress.tls.secretName }}
+{{- end -}}

--- a/charts/confluent/templates/031.ksqldb-ingress.yaml
+++ b/charts/confluent/templates/031.ksqldb-ingress.yaml
@@ -1,0 +1,25 @@
+{{- $ksqldb := .Values.lsdmesp.confluent.ksqldb -}}
+{{- if $ksqldb.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ksqldb
+spec:
+  ingressClassName: {{ $ksqldb.ingress.ingressClassName }}
+  rules:
+    - host: ksqldb.{{ $ksqldb.ingress.baseDomain }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: ksqldb
+                port:
+                  number: 9092
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - ksqldb.{{ $ksqldb.ingress.baseDomain }}
+      secretName: {{ $ksqldb.ingress.tls.secretName }}
+{{- end -}}

--- a/charts/confluent/templates/050.controlcenter-ingress.yaml
+++ b/charts/confluent/templates/050.controlcenter-ingress.yaml
@@ -1,0 +1,25 @@
+{{- $controlcenter := .Values.lsdmesp.confluent.controlcenter -}}
+{{- if $controlcenter.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-controlcenter
+spec:
+  ingressClassName: {{ $controlcenter.ingress.ingressClassName }}
+  rules:
+    - host: controlcenter.{{ $controlcenter.ingress.baseDomain }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: controlcenter
+                port:
+                  number: 9092
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - controlcenter.{{ $controlcenter.ingress.baseDomain }}
+      secretName: {{ $controlcenter.ingress.tls.secretName }}
+{{- end -}}

--- a/charts/confluent/values.yaml
+++ b/charts/confluent/values.yaml
@@ -86,6 +86,18 @@ lsdmesp:
           memory: 3Gi
       # number of pod replicas
       replicas: 3
+      externalAccess: {}
+      ingress:
+        # -- Specifies whether an ingress for Kafka should be created
+        enabled: false
+        ingressClassName: "nginx"
+        # -- Annotations for the Kafka ingress
+        annotations: {}
+        # -- Base domain configuration for the Kafka and brokers ingress ingress
+        baseDomain: "example.com"
+        # -- TLS host configuration will be dynamically built based on the base domain. You can change the secret name here.
+        tls:
+          secretName: kafka-tls
 
     kafkarestclass:
       # if `true`, then will be provisioned
@@ -111,6 +123,18 @@ lsdmesp:
           memory: 512Mi
       # number of pod replicas
       replicas: 1
+      externalAccess: {}
+      ingress:
+        # -- Specifies whether an ingress for Schema Registry should be created
+        enabled: false
+        ingressClassName: "nginx"
+        # -- Annotations for the Schema Registry ingress
+        annotations: {}
+        # -- Base domain configuration for the  Schema Registry ingress
+        baseDomain: "example.com"
+        # -- TLS host configuration will be dynamically built based on the base domain. You can change the secret name here.
+        tls:
+          secretName: schemaregistry-tls
 
     connect:
       # if `true`, then will be provisioned
@@ -132,6 +156,18 @@ lsdmesp:
           memory: 1Gi
       # number of pod replicas
       replicas: 1
+      externalAccess: {}
+      ingress:
+        # -- Specifies whether an ingress for Connect should be created
+        enabled: false
+        ingressClassName: "nginx"
+        # -- Annotations for the Connect ingress
+        annotations: {}
+        # -- Base domain configuration for the  Connect ingress
+        baseDomain: "example.com"
+        # -- TLS host configuration will be dynamically built based on the base domain. You can change the secret name here.
+        tls:
+          secretName: connect-tls
 
     ksqldb:
       # if `true`, then will be provisioned
@@ -155,6 +191,18 @@ lsdmesp:
           memory: 1Gi
       # number of pod replicas
       replicas: 1
+      externalAccess: {}
+      ingress:
+        # -- Specifies whether an ingress for KSQLDB should be created
+        enabled: false
+        ingressClassName: "nginx"
+        # -- Annotations for the KSQLDB ingress
+        annotations: {}
+        # -- Base domain configuration for the KSQLDB ingress
+        baseDomain: "example.com"
+        # -- TLS host configuration will be dynamically built based on the base domain. You can change the secret name here.
+        tls:
+          secretName: ksqldb-tls
 
     kafkarestproxy:
       # if `true`, then will be provisioned
@@ -199,6 +247,18 @@ lsdmesp:
           memory: 6Gi
       # number of pod replicas
       replicas: 1
+      externalAccess: {}
+      ingress:
+        # -- Specifies whether an ingress for Control Center should be created
+        enabled: false
+        ingressClassName: "nginx"
+        # -- Annotations for the Control Center ingress
+        annotations: {}
+        # -- Base domain configuration for the Control Center ingress
+        baseDomain: "example.com"
+        # -- TLS host configuration will be dynamically built based on the base domain. You can change the secret name here.
+        tls:
+          secretName: controlcenter-tls
 
 confluent-for-kubernetes:
   name: confluent-operator


### PR DESCRIPTION
This gives the ability for ingress to be deployed if needed, it also allows for the external access block to be set for things like routes or NodePort for on-prem clusters